### PR TITLE
Fix .env to work when used to create or run docker images

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
-PORT=9010 # Http Bridge Port
-HOST="0.0.0.0" # Http Bridge Host (DONT CHANGE id running with Docker)
-API_URL=https://smartcity.heraklion.gr/open-data-api # Base URL of the API
+PORT=9010
+# Http Bridge Port
+
+HOST=0.0.0.0
+# Http Bridge Host (DONT CHANGE id running with Docker)
+
+API_URL=https://smartcity.heraklion.gr/open-data-api
+# Base URL of the API


### PR DESCRIPTION
Docker's .env parser considers as comments only lines that start with #, variable declarations followed by spaces or comments will include them as part of the variable's value. This makes the container fail silently while printing a misleading message (e.g., "Running on port 9010 # Http Bridge Port" where the whole text "9010 # Http Bridge Port" is actualy the port used. Additionally some parsers will not work with "0.0.0.0". I changed these aspects so the .env file does not make the container for the http-bridge fail silently.